### PR TITLE
added ui screens for todolist and auth with github

### DIFF
--- a/extension/media/vscode.css
+++ b/extension/media/vscode.css
@@ -34,6 +34,12 @@ a {
 	color: var(--vscode-textLink-foreground);
 }
 
+select,option{
+	background-color: var(--vscode-input-background);
+	color:var(--vscode-button-foreground);
+	border-color: var(--vscode-input-background);;
+}
+
 a:hover,
 a:active {
 	color: var(--vscode-textLink-activeForeground);

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "todo-plus-plus",
+	"name": "todo-plus-plus",
 	"displayName": "Todo_plus_plus",
 	"description": "An overly fancy todo list in vscode",
 	"version": "0.0.1",
@@ -10,7 +10,7 @@
 		"Other"
 	],
 	"activationEvents": [
-        "onCommand:todo-plus-plus.helloWorld",
+		"onCommand:todo-plus-plus.helloWorld",
 		"onView:todo-plus-plus-sidebar"
 	],
 	"main": "./dist/extension.js",
@@ -54,30 +54,33 @@
 		"test": "node ./out/test/runTest.js"
 	},
 	"devDependencies": {
-		"@types/vscode": "^1.53.0",
-		"@types/glob": "^7.1.3",
-		"@types/mocha": "^8.0.4",
-		"@types/node": "^12.11.7",
-		"eslint": "^7.19.0",
-		"@typescript-eslint/eslint-plugin": "^4.14.1",
-		"@typescript-eslint/parser": "^4.14.1",
-		"glob": "^7.1.6",
-		"mocha": "^8.2.1",
-		"typescript": "^4.1.3",
-		"vscode-test": "^1.5.0",
-		"ts-loader": "^8.0.14",
-		"webpack": "^5.19.0",
-		"webpack-cli": "^4.4.0",
 		"@rollup/plugin-commonjs": "^17.1.0",
 		"@rollup/plugin-node-resolve": "^11.1.1",
 		"@rollup/plugin-typescript": "^8.1.1",
 		"@tsconfig/svelte": "^1.0.10",
+		"@types/glob": "^7.1.3",
+		"@types/mocha": "^8.0.4",
+		"@types/node": "^12.11.7",
+		"@types/vscode": "^1.53.0",
+		"@typescript-eslint/eslint-plugin": "^4.14.1",
+		"@typescript-eslint/parser": "^4.14.1",
 		"concurrently": "^5.3.0",
+		"eslint": "^7.19.0",
+		"glob": "^7.1.6",
+		"mocha": "^8.2.1",
 		"rollup": "^2.3.4",
 		"rollup-plugin-svelte": "^6.0.0",
 		"rollup-plugin-terser": "^7.0.2",
 		"svelte": "^3.32.3",
 		"svelte-check": "^1.1.34",
-		"svelte-preprocess": "^4.6.8"
+		"svelte-preprocess": "^4.6.8",
+		"ts-loader": "^8.0.14",
+		"typescript": "^4.1.3",
+		"vscode-test": "^1.5.0",
+		"webpack": "^5.19.0",
+		"webpack-cli": "^4.4.0"
+	},
+	"dependencies": {
+		"vscode-codicons": "^0.0.14"
 	}
 }

--- a/extension/src/SidebarProvider.ts
+++ b/extension/src/SidebarProvider.ts
@@ -45,6 +45,9 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
   }
 
   private _getHtmlForWebview(webview: vscode.Webview) {
+    const codiconsUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(this._extensionUri, 'node_modules', 'vscode-codicons', 'dist', 'codicon.css')
+    );
     const styleResetUri = webview.asWebviewUri(
       vscode.Uri.joinPath(this._extensionUri, "media", "reset.css")
     );
@@ -69,12 +72,12 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 					Use a content security policy to only allow loading images from https or from our extension directory,
 					and only allow scripts that have a specific nonce.
         -->
-        <meta http-equiv="Content-Security-Policy" content=" script-src 'nonce-${nonce}';">
+        <meta http-equiv="Content-Security-Policy" content="img-src https: data: ; style-src 'unsafe-inline' ${webview.cspSource}; script-src 'nonce-${nonce}';">
 				<meta name="viewport" content="width=device-width, initial-scale=1.0">
 				<link href="${styleResetUri}" rel="stylesheet">
 				<link href="${styleVSCodeUri}" rel="stylesheet">
         <link href="${styleMainUri}" rel="stylesheet">
-
+        <link href="${codiconsUri}" rel="stylesheet">
 			</head>
       <body>
 				<script nonce="${nonce}" src="${scriptUri}"></script>

--- a/extension/webviews/components/auth.svelte
+++ b/extension/webviews/components/auth.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+    let src = 'https://www.vhv.rs/dpng/d/420-4200678_octocat-github-logo-transparent-github-for-government-octocat.png';
+    let src2= './github.png'
+</script>
+
+<style>
+    .parent{
+        display: flex;
+        text-align: center;
+        flex-direction: column;
+        justify-content: space-evenly;
+    }
+    i{
+        margin-right:2px;
+        margin-top: 5px;
+    }
+</style>
+
+
+<div class="parent">
+    <br/>
+    <button type="submit"> 
+        <div class="icon"><i class="codicon codicon-github-inverted"></i>
+        Login with Github
+        </div>
+    </button>
+    <br/>
+    <button type="submit"> 
+        <div class="icon"><i class="codicon codicon-account"></i>
+        Sign In Anonymously
+        </div>
+    </button>
+</div>

--- a/extension/webviews/components/auth.svelte
+++ b/extension/webviews/components/auth.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-    let src = 'https://www.vhv.rs/dpng/d/420-4200678_octocat-github-logo-transparent-github-for-government-octocat.png';
-    let src2= './github.png'
 </script>
 
 <style>
@@ -10,23 +8,25 @@
         flex-direction: column;
         justify-content: space-evenly;
     }
-    i{
-        margin-right:2px;
-        margin-top: 5px;
+    .icon-align-fix {
+        position: relative;
+        margin-right: 2px;
+        top: 2px;
     }
+
 </style>
 
 
 <div class="parent">
     <br/>
     <button type="submit"> 
-        <div class="icon"><i class="codicon codicon-github-inverted"></i>
+        <div class="icon"><i class="codicon codicon-github-inverted icon-align-fix"></i>
         Login with Github
         </div>
     </button>
     <br/>
     <button type="submit"> 
-        <div class="icon"><i class="codicon codicon-account"></i>
+        <div class="icon"><i class="codicon codicon-account icon-align-fix"></i>
         Sign In Anonymously
         </div>
     </button>

--- a/extension/webviews/components/sidebar.svelte
+++ b/extension/webviews/components/sidebar.svelte
@@ -1,28 +1,17 @@
 <script lang="ts">
-    let todos:Array<{text: string;completed:boolean}>=[];
-    let text="";
+    import Todolist from "./todolist.svelte";
+    import Auth from "./auth.svelte";
+    let currentPage="Auth";
 </script>
-<style>
-    h2{
-        color:orange;
-    }
-    .completed{
-        text-decoration: line-through;
-    }
-</style>
-<h2>Todolist: Make todos here!</h2>
-<form on:submit|preventDefault={()=>{
-    todos=[...todos,{text,completed:false}];
-    text="";
-}}>
-    <input bind:value={text}  />
-</form>
-<ul>
-    {#each todos as todo (todo.text)}
-        <li class:completed={todo.completed}
-            on:click={()=>{
-                todo.completed=!todo.completed
-            }}
-        >{todo.text}</li>
-    {/each}
-</ul>
+
+{#if currentPage=='Auth'}
+    <Auth/>
+    <button on:click={()=>{
+        currentPage="Todo";
+    }}>Change to todolist</button>
+{:else if currentPage=='Todo'}
+    <Todolist />
+    <button on:click={()=>{
+        currentPage="Auth";
+    }}>Change to Auth</button>
+{/if}

--- a/extension/webviews/components/todolist.svelte
+++ b/extension/webviews/components/todolist.svelte
@@ -71,9 +71,9 @@
         text="";
         description="";
     }}>
-        <label>Todo</label>
+        <p>Todo</p>
         <input bind:value={text}  />
-        <label>Description</label>
+        <p>Description</p>
         <textarea bind:value={description}  />
 
         <!-- Code for categories -->

--- a/extension/webviews/components/todolist.svelte
+++ b/extension/webviews/components/todolist.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+    let todos:Array<{text: string;description: string,completed:boolean}>=[];
+    let text="";
+    let makeTodoVisiblity=false;
+    let description="";
+    // code for categories
+    // let selectedCategory='Select Category'
+    // let categories=['category1','category2','category3']
+</script>
+<style>
+    input{
+        height: 25px;
+    }
+    /* category styling */
+    /* option,select{
+        height: 35px;
+        width: 100%;
+    } */
+    ul{
+        list-style-type:none;
+    }
+    .todoitem{
+        display: flex;
+    }
+    h4{
+        font-weight: bold;
+        text-transform: capitalize;
+    }
+    .todocheckbox{
+        margin-right: 10px;
+    }
+    input[type=checkbox]:focus{
+        outline-color:none;
+    }
+    .interaction-buttons{
+        display: flex;
+    }
+    .interaction-buttons p{
+        cursor: pointer;
+        margin-right: 15px;
+        font-size: small;
+    }
+    .todo-text{
+        width:100%;
+    }
+    .maketodo-toggle{
+        cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+    }
+    .icon-text{
+        display: flex;
+        color: var(--vscode-textLink-foreground);
+    }
+    .description{
+        margin:2px;
+    }
+</style>
+<h2>Todolist: Make todos here!</h2>
+<div class="maketodo-toggle" on:click={()=>{makeTodoVisiblity=!makeTodoVisiblity}}>
+    <p>Make Todos</p>
+    {#if makeTodoVisiblity}
+        <div class="icon"><i class="codicon codicon-chevron-up"></i></div>
+    {:else}
+        <div class="icon"><i class="codicon codicon-chevron-down"></i></div>
+    {/if}
+</div>
+{#if makeTodoVisiblity}
+    <form on:submit|preventDefault={()=>{
+        todos=[...todos,{text,completed:false,description}];
+        text="";
+        description="";
+    }}>
+        <label>Todo</label>
+        <input bind:value={text}  />
+        <label>Description</label>
+        <textarea bind:value={description}  />
+
+        <!-- Code for categories -->
+        <!-- <label>Category:</label>
+        <br/>
+        <select value={selectedCategory}>
+            {#each categories as category}
+                <option value={category}>
+                    {category}
+                </option>
+            {/each}
+        </select> -->
+
+        <br/>
+        <button type="submit">Add Todo</button>
+
+    </form>
+    <br/>
+    
+{/if}
+
+<hr/>
+<p>View Todos</p>
+<ul>
+    {#each todos as todo (todo.text)}
+        <li class:completed={todo.completed}
+            class="todoitem"
+            on:click={()=>{
+                todo.completed=!todo.completed
+            }}
+        >
+        <input class="todocheckbox" type=checkbox checked={false}>
+        <div class="todo-text">
+        <h4>{todo.text}</h4>
+        <p class="description">{todo.description}</p>
+        <div class="interaction-buttons">
+            <div class="icon-text">
+                <div class="icon">
+                    <i class="codicon codicon-issues"></i>
+                </div>
+                <p>Push as an issue</p>
+            </div>
+            <div class="icon-text">
+                <div class="icon">
+                    <i class="codicon codicon-trash"></i>
+                </div>
+                <p>Delete</p>
+            </div>
+        </div>
+        </div>
+        </li>
+    {/each}
+</ul>

--- a/extension/webviews/components/todolist.svelte
+++ b/extension/webviews/components/todolist.svelte
@@ -40,6 +40,9 @@
         margin-right: 15px;
         font-size: small;
     }
+    .todolist{
+        padding-left:0;
+    }
     .todo-text{
         width:100%;
     }
@@ -54,6 +57,11 @@
     }
     .description{
         margin:2px;
+    }
+    .icon-align-fix {
+        position: relative;
+        margin-right: 2px;
+        top: 2px;
     }
 </style>
 <h2>Todolist: Make todos here!</h2>
@@ -97,7 +105,7 @@
 
 <hr/>
 <p>View Todos</p>
-<ul>
+<ul class="todolist">
     {#each todos as todo (todo.text)}
         <li class:completed={todo.completed}
             class="todoitem"
@@ -112,13 +120,13 @@
         <div class="interaction-buttons">
             <div class="icon-text">
                 <div class="icon">
-                    <i class="codicon codicon-issues"></i>
+                    <i class="codicon codicon-issues icon-align-fix"></i>
                 </div>
                 <p>Push as an issue</p>
             </div>
             <div class="icon-text">
                 <div class="icon">
-                    <i class="codicon codicon-trash"></i>
+                    <i class="codicon codicon-trash icon-align-fix"></i>
                 </div>
                 <p>Delete</p>
             </div>

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -2490,6 +2490,11 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+vscode-codicons@^0.0.14:
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/vscode-codicons/-/vscode-codicons-0.0.14.tgz#e0d05418e2e195564ff6f6a2199d70415911c18f"
+  integrity sha512-6CEH5KT9ct5WMw7n5dlX7rB8ya4CUI2FSq1Wk36XaW+c5RglFtAanUV0T+gvZVVFhl/WxfjTvFHq06Hz9c1SLA==
+
 vscode-test@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/vscode-test/-/vscode-test-1.5.0.tgz#7bcb6b1aeac41d35c29f4404f8ca3399ae52e78e"


### PR DESCRIPTION
Added screens for actual todolist and auth screen with buttons to login with github or sign in anonymously. Also added a toggle button on the screens to go from one to other, attaching screenshots for reference.
Closes #24 #22 

<img src="https://user-images.githubusercontent.com/44273715/108163555-41601580-7115-11eb-98da-b2ffae1e8826.png" alt="drawing" width="200"/>
<img src="https://user-images.githubusercontent.com/44273715/108163822-a3b91600-7115-11eb-8f79-a0eed4b3c2d0.png" alt="drawing" width="200"/>